### PR TITLE
isnanf function support for MacOs

### DIFF
--- a/src/lib/libum.c
+++ b/src/lib/libum.c
@@ -746,7 +746,7 @@ static int um_set_drive_status(um_state *hndl, const int dev, const int value)
 }
 
 
-#ifdef _WINDOWS
+#if defined(_WINDOWS) || (defined(__APPLE__) && defined(__MACH__))
 static bool isnanf(const float arg)
 {   return isnan(arg); }
 #endif

--- a/src/sample/sample.c
+++ b/src/sample/sample.c
@@ -186,7 +186,7 @@ void parse_args(int argc, char *argv[], params_struct *params)
     }
 }
 
-#ifdef _WINDOWS
+#if defined(_WINDOWS) || (defined(__APPLE__) && defined(__MACH__))
 static bool isnanf(const float arg)
 {
     return isnan(arg);


### PR DESCRIPTION
Added ifdefs for Apple & MACH OS to libum.c and sample.